### PR TITLE
Reward matching the pattern at index zero

### DIFF
--- a/src/Text/Fuzzy.hs
+++ b/src/Text/Fuzzy.hs
@@ -65,7 +65,10 @@ match pattern t pre post extract caseSensitive =
                   let cur' = cur * 2 + 1 in
                   (tot + cur', cur', res <> pre <> T.singleton c <> post, xs)
                 else (tot, 0, res <> T.singleton c, pat)
-        ) (0, 0, mempty, pattern') s'
+        ) ( 0 
+          , 1  -- reward prefix matching
+          , mempty
+          , pattern') s'
 
 -- | The function to filter a list of values by fuzzy search on the text extracted from them.
 --


### PR DESCRIPTION
When matching `hea` with `head` and `NoheapProfiling`, it's a bit confusing that both get the same score. 

One way around this is to prime the initial 'current' score in order to reward the first match. If there is a better ways to do this, please point it out.

I'm assuming that this is always desirable, but if not please let me know and I'll add another config parameter